### PR TITLE
[ENG-17] feat: auto refresh tokens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ async function authenticate() {
         const authUrl = oauth2Client.generateAuthUrl({
             access_type: 'offline',
             scope: ['https://www.googleapis.com/auth/gmail.modify'],
+            prompt: 'consent',
         });
 
         console.log('Please visit this URL to authenticate:', authUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ async function loadCredentials() {
         let oauthPath = OAUTH_PATH;
 
         if (fs.existsSync(localOAuthPath)) {
+            // If found in current directory, copy to config directory
             fs.copyFileSync(localOAuthPath, OAUTH_PATH);
             console.log('OAuth keys found in current directory, copied to global config.');
         }
@@ -164,9 +165,7 @@ async function authenticate() {
     return new Promise<void>((resolve, reject) => {
         const authUrl = oauth2Client.generateAuthUrl({
             access_type: 'offline',
-            prompt: 'consent',
             scope: ['https://www.googleapis.com/auth/gmail.modify'],
-            access_type_extended: true
         });
 
         console.log('Please visit this URL to authenticate:', authUrl);
@@ -187,12 +186,7 @@ async function authenticate() {
 
             try {
                 const { tokens } = await oauth2Client.getToken(code);
-                oauth2Client.setCredentials(tokens);
-
-                console.log('Refresh token received:', !!tokens.refresh_token);
-                console.log('Access token expires in:', tokens.expiry_date ? 
-                    new Date(tokens.expiry_date).toLocaleTimeString() : 'N/A');
-                
+                oauth2Client.setCredentials(tokens);                
                 fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(tokens));
 
                 res.writeHead(200);

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,8 +267,9 @@ function parseEmailAddresses(addressString: string): string[] {
 // Main function
 async function main() {
     await loadCredentials();
+    let refreshed = false;
+    if (!process.argv.includes("--disable-refresh")) refreshed =await refreshCredentials();
     if (process.argv[2] === 'auth') {
-        const refreshed = await refreshCredentials();
         if (process.argv.includes('--force') || !refreshed) {
             await authenticate();
             console.log('Authentication completed successfully');
@@ -339,9 +340,6 @@ async function main() {
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { name, arguments: args } = request.params;
-        if (process.argv.includes('--auto-refresh')) {
-            refreshCredentials();
-        }
 
         async function handleEmailAction(action: "send" | "draft", validatedArgs: any) {
             const message = createEmailMessage(validatedArgs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ async function authenticate() {
 
             try {
                 const { tokens } = await oauth2Client.getToken(code);
-                oauth2Client.setCredentials(tokens);                
+                oauth2Client.setCredentials(tokens);
                 fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(tokens));
 
                 res.writeHead(200);


### PR DESCRIPTION
This PR adds the ability for the gmail-mcp server to automatically refresh it's token when the process starts up. This allows the MCP server to continue to be used as long as there is a call to the server within the refresh token's expiry date.

## Considerations
1. This requires a consent page when first authenticating the user. This allows the refresh token to be passed through in addition to the access token
2. Currently our Google API only allows a refresh token to be valid for 1 hour after any refresh - so if the server is not called for 1 hour, then it will expire. This can be circumvented by running `npx @mjamei/gmail-mcp auth` on a regular interval in order to keep the token up to date, but it will have to be in a separate process probably.